### PR TITLE
send to loggly for all log levels

### DIFF
--- a/log.go
+++ b/log.go
@@ -244,10 +244,6 @@ func getNowDate() string {
 
 // buildAndShipMessage creates the *logMessage to be send to loggly (adding current time) and ship it (send or add to the buffer)
 func buildAndShipMessage(output string, messageType string, exit bool, data map[string]interface{}) {
-	if loggerSingleton.Level > LogLevelDebug {
-		return
-	}
-
 	var formattedOutput string
 
 	if data == nil {

--- a/log.go
+++ b/log.go
@@ -351,6 +351,12 @@ func flush() {
 	loggerSingleton.Unlock()
 
 	body := formatBulkMessages(messages)
+	if len(body) == 0 {
+		if loggerSingleton.debugMode {
+			fmt.Println("No logs to send: Status OK")
+		}
+		return
+	}
 
 	resp, err := http.Post(loggerSingleton.url, "text/plain", bytes.NewBuffer([]byte(body)))
 	if err != nil {


### PR DESCRIPTION
I don't know why this was intentionally this way, but prevented the logs to being sent to loggly if log level was info or higher.
Logs were printed to console anyway, just they were not sent